### PR TITLE
fix: correct 'cacabinetet' -> 'cabinet' in MCP_CONFIG and server docstring

### DIFF
--- a/api-service/config.py
+++ b/api-service/config.py
@@ -37,9 +37,9 @@ SERVER_CONFIG = {
 MCP_CONFIG = {
     "exposed_tools": [
         {
-            "name": "retrieve_from_cacabinetet",
-            "description": "Retrieve context from a specific cacabinetet using a query",
-            "params": ["cacabinetet_name", "query"]
+            "name": "retrieve_from_cabinet",
+            "description": "Retrieve context from a specific cabinet using a query",
+            "params": ["cabinet_name", "query"]
         },
         {
             "name": "list_cabinets",

--- a/api-service/server.py
+++ b/api-service/server.py
@@ -1,6 +1,6 @@
 # File: /mcp-cabinets/api-service/server.py
 """
-FastAPI server with LlamaIndex integration for per-cacabinetet text indexing and retrieval
+FastAPI server with LlamaIndex integration for per-cabinet text indexing and retrieval
 """
 import json
 import math


### PR DESCRIPTION
## Summary

\`api-service/config.py\` MCP \`exposed_tools\` block used the typo \`cacabinetet\` (an extra \"ca…et\" wrapping \`cabinet\`) three times — tool \`name\`, \`description\`, and the \`params\` list — and \`api-service/server.py\` module docstring read \`per-cacabinetet\`. Every other occurrence in the codebase already uses the correct \`cabinet\` spelling.

Changes:
- \`retrieve_from_cacabinetet\` -> \`retrieve_from_cabinet\`
- \`cacabinetet\` (description) -> \`cabinet\`
- \`cacabinetet_name\` (param) -> \`cabinet_name\`
- \`per-cacabinetet\` (server docstring) -> \`per-cabinet\`

Closes #4

## Testing

String-only fix; no logic altered. All other call sites and keys already use \`cabinet\`.